### PR TITLE
Allow s3 logging from aws_s3_bucket_logging

### DIFF
--- a/rego/rules/tf/aws/s3/bucket_access_logging.rego
+++ b/rego/rules/tf/aws/s3/bucket_access_logging.rego
@@ -29,8 +29,15 @@ resource_type := "MULTIPLE"
 
 buckets := fugue.resources("aws_s3_bucket")
 
+bucket_logging := fugue.resources("aws_s3_bucket_logging")
+
 bucket_has_logging(bucket) {
   _ = bucket.logging[_]
+}
+
+bucket_has_logging(bucket) {
+  bucket_logging_conf := bucket_logging[_]
+  bucket_logging_conf.bucket == bucket.id
 }
 
 bucket_has_logging(bucket) {

--- a/rego/tests/rules/tf/aws/s3/inputs/bucket_logging_infra.json
+++ b/rego/tests/rules/tf/aws/s3/inputs/bucket_logging_infra.json
@@ -1,0 +1,440 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.5.7",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_s3_bucket.allow_attached_resource_logging",
+          "mode": "managed",
+          "type": "aws_s3_bucket",
+          "name": "allow_attached_resource_logging",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "bucket": "allow-attached-resource-logging",
+            "force_destroy": false,
+            "tags": null,
+            "timeouts": null
+          },
+          "sensitive_values": {
+            "cors_rule": [],
+            "grant": [],
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "replication_configuration": [],
+            "server_side_encryption_configuration": [],
+            "tags_all": {},
+            "versioning": [],
+            "website": []
+          }
+        },
+        {
+          "address": "aws_s3_bucket.allow_inline_logging",
+          "mode": "managed",
+          "type": "aws_s3_bucket",
+          "name": "allow_inline_logging",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "bucket": "allow-directly-attached-logging",
+            "force_destroy": false,
+            "logging": [
+              {
+                "target_prefix": "/allow_inline_logging/"
+              }
+            ],
+            "tags": null,
+            "timeouts": null
+          },
+          "sensitive_values": {
+            "cors_rule": [],
+            "grant": [],
+            "lifecycle_rule": [],
+            "logging": [
+              {}
+            ],
+            "object_lock_configuration": [],
+            "replication_configuration": [],
+            "server_side_encryption_configuration": [],
+            "tags_all": {},
+            "versioning": [],
+            "website": []
+          }
+        },
+        {
+          "address": "aws_s3_bucket.deny_no_logging",
+          "mode": "managed",
+          "type": "aws_s3_bucket",
+          "name": "deny_no_logging",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "bucket": "allow-directly-attached-logging",
+            "force_destroy": false,
+            "tags": null,
+            "timeouts": null
+          },
+          "sensitive_values": {
+            "cors_rule": [],
+            "grant": [],
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "replication_configuration": [],
+            "server_side_encryption_configuration": [],
+            "tags_all": {},
+            "versioning": [],
+            "website": []
+          }
+        },
+        {
+          "address": "aws_s3_bucket_logging.allow_attached_resource_logging_name_does_not_match",
+          "mode": "managed",
+          "type": "aws_s3_bucket_logging",
+          "name": "allow_attached_resource_logging_name_does_not_match",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "expected_bucket_owner": null,
+            "target_grant": [],
+            "target_object_key_format": [],
+            "target_prefix": "/allow_attached_resource_logging/"
+          },
+          "sensitive_values": {
+            "target_grant": [],
+            "target_object_key_format": []
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "aws_s3_bucket.allow_attached_resource_logging",
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "allow_attached_resource_logging",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "bucket": "allow-attached-resource-logging",
+          "force_destroy": false,
+          "tags": null,
+          "timeouts": null
+        },
+        "after_unknown": {
+          "acceleration_status": true,
+          "acl": true,
+          "arn": true,
+          "bucket_domain_name": true,
+          "bucket_prefix": true,
+          "bucket_regional_domain_name": true,
+          "cors_rule": true,
+          "grant": true,
+          "hosted_zone_id": true,
+          "id": true,
+          "lifecycle_rule": true,
+          "logging": true,
+          "object_lock_configuration": true,
+          "object_lock_enabled": true,
+          "policy": true,
+          "region": true,
+          "replication_configuration": true,
+          "request_payer": true,
+          "server_side_encryption_configuration": true,
+          "tags_all": true,
+          "versioning": true,
+          "website": true,
+          "website_domain": true,
+          "website_endpoint": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "cors_rule": [],
+          "grant": [],
+          "lifecycle_rule": [],
+          "logging": [],
+          "object_lock_configuration": [],
+          "replication_configuration": [],
+          "server_side_encryption_configuration": [],
+          "tags_all": {},
+          "versioning": [],
+          "website": []
+        }
+      }
+    },
+    {
+      "address": "aws_s3_bucket.allow_inline_logging",
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "allow_inline_logging",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "bucket": "allow-directly-attached-logging",
+          "force_destroy": false,
+          "logging": [
+            {
+              "target_prefix": "/allow_inline_logging/"
+            }
+          ],
+          "tags": null,
+          "timeouts": null
+        },
+        "after_unknown": {
+          "acceleration_status": true,
+          "acl": true,
+          "arn": true,
+          "bucket_domain_name": true,
+          "bucket_prefix": true,
+          "bucket_regional_domain_name": true,
+          "cors_rule": true,
+          "grant": true,
+          "hosted_zone_id": true,
+          "id": true,
+          "lifecycle_rule": true,
+          "logging": [
+            {
+              "target_bucket": true
+            }
+          ],
+          "object_lock_configuration": true,
+          "object_lock_enabled": true,
+          "policy": true,
+          "region": true,
+          "replication_configuration": true,
+          "request_payer": true,
+          "server_side_encryption_configuration": true,
+          "tags_all": true,
+          "versioning": true,
+          "website": true,
+          "website_domain": true,
+          "website_endpoint": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "cors_rule": [],
+          "grant": [],
+          "lifecycle_rule": [],
+          "logging": [
+            {}
+          ],
+          "object_lock_configuration": [],
+          "replication_configuration": [],
+          "server_side_encryption_configuration": [],
+          "tags_all": {},
+          "versioning": [],
+          "website": []
+        }
+      }
+    },
+    {
+      "address": "aws_s3_bucket.deny_no_logging",
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "deny_no_logging",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "bucket": "allow-directly-attached-logging",
+          "force_destroy": false,
+          "tags": null,
+          "timeouts": null
+        },
+        "after_unknown": {
+          "acceleration_status": true,
+          "acl": true,
+          "arn": true,
+          "bucket_domain_name": true,
+          "bucket_prefix": true,
+          "bucket_regional_domain_name": true,
+          "cors_rule": true,
+          "grant": true,
+          "hosted_zone_id": true,
+          "id": true,
+          "lifecycle_rule": true,
+          "logging": true,
+          "object_lock_configuration": true,
+          "object_lock_enabled": true,
+          "policy": true,
+          "region": true,
+          "replication_configuration": true,
+          "request_payer": true,
+          "server_side_encryption_configuration": true,
+          "tags_all": true,
+          "versioning": true,
+          "website": true,
+          "website_domain": true,
+          "website_endpoint": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "cors_rule": [],
+          "grant": [],
+          "lifecycle_rule": [],
+          "logging": [],
+          "object_lock_configuration": [],
+          "replication_configuration": [],
+          "server_side_encryption_configuration": [],
+          "tags_all": {},
+          "versioning": [],
+          "website": []
+        }
+      }
+    },
+    {
+      "address": "aws_s3_bucket_logging.allow_attached_resource_logging_name_does_not_match",
+      "mode": "managed",
+      "type": "aws_s3_bucket_logging",
+      "name": "allow_attached_resource_logging_name_does_not_match",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "expected_bucket_owner": null,
+          "target_grant": [],
+          "target_object_key_format": [],
+          "target_prefix": "/allow_attached_resource_logging/"
+        },
+        "after_unknown": {
+          "bucket": true,
+          "id": true,
+          "target_bucket": true,
+          "target_grant": [],
+          "target_object_key_format": []
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "target_grant": [],
+          "target_object_key_format": []
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "aws": {
+        "name": "aws",
+        "full_name": "registry.terraform.io/hashicorp/aws",
+        "expressions": {
+          "region": {
+            "constant_value": "us-east-1"
+          }
+        }
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_s3_bucket.allow_attached_resource_logging",
+          "mode": "managed",
+          "type": "aws_s3_bucket",
+          "name": "allow_attached_resource_logging",
+          "provider_config_key": "aws",
+          "expressions": {
+            "bucket": {
+              "constant_value": "allow-attached-resource-logging"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_s3_bucket.allow_inline_logging",
+          "mode": "managed",
+          "type": "aws_s3_bucket",
+          "name": "allow_inline_logging",
+          "provider_config_key": "aws",
+          "expressions": {
+            "bucket": {
+              "constant_value": "allow-directly-attached-logging"
+            },
+            "logging": [
+              {
+                "target_bucket": {
+                  "references": [
+                    "aws_s3_bucket.deny_no_logging.id",
+                    "aws_s3_bucket.deny_no_logging"
+                  ]
+                },
+                "target_prefix": {
+                  "constant_value": "/allow_inline_logging/"
+                }
+              }
+            ]
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_s3_bucket.deny_no_logging",
+          "mode": "managed",
+          "type": "aws_s3_bucket",
+          "name": "deny_no_logging",
+          "provider_config_key": "aws",
+          "expressions": {
+            "bucket": {
+              "constant_value": "allow-directly-attached-logging"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_s3_bucket_logging.allow_attached_resource_logging_name_does_not_match",
+          "mode": "managed",
+          "type": "aws_s3_bucket_logging",
+          "name": "allow_attached_resource_logging_name_does_not_match",
+          "provider_config_key": "aws",
+          "expressions": {
+            "bucket": {
+              "references": [
+                "aws_s3_bucket.allow_attached_resource_logging.id",
+                "aws_s3_bucket.allow_attached_resource_logging"
+              ]
+            },
+            "target_bucket": {
+              "references": [
+                "aws_s3_bucket.deny_no_logging.id",
+                "aws_s3_bucket.deny_no_logging"
+              ]
+            },
+            "target_prefix": {
+              "constant_value": "/allow_attached_resource_logging/"
+            }
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  },
+  "relevant_attributes": [
+    {
+      "resource": "aws_s3_bucket.allow_attached_resource_logging",
+      "attribute": [
+        "id"
+      ]
+    },
+    {
+      "resource": "aws_s3_bucket.deny_no_logging",
+      "attribute": [
+        "id"
+      ]
+    }
+  ],
+  "timestamp": "2024-04-19T20:43:56Z"
+}

--- a/rego/tests/rules/tf/aws/s3/inputs/bucket_logging_infra.tf
+++ b/rego/tests/rules/tf/aws/s3/inputs/bucket_logging_infra.tf
@@ -1,0 +1,49 @@
+# Copyright 2020 Fugue, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# terraform file that generated bucketpolicy_allowlist_infra.json
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "deny_no_logging" {
+  bucket = "allow-directly-attached-logging"
+}
+
+resource "aws_s3_bucket" "allow_inline_logging" {
+  bucket = "allow-directly-attached-logging"
+  logging {
+    target_bucket = aws_s3_bucket.deny_no_logging.id
+    target_prefix = "/allow_inline_logging/"
+  }
+}
+
+resource "aws_s3_bucket" "allow_attached_resource_logging" {
+  bucket = "allow-attached-resource-logging"
+}
+
+resource "aws_s3_bucket_logging" "allow_attached_resource_logging_name_does_not_match" {
+  bucket = aws_s3_bucket.allow_attached_resource_logging.id
+
+  target_bucket = aws_s3_bucket.deny_no_logging.id
+  target_prefix = "/allow_attached_resource_logging/"
+}
+
+resource "aws_s3_bucket_logging" "not_attached_to_anything" {
+  bucket = aws_s3_bucket.allow_attached_resource_logging.id
+
+  target_bucket = aws_s3_bucket.deny_no_logging.id
+  target_prefix = "/allow_attached_resource_logging/"
+}

--- a/rego/tests/rules/tf/aws/s3/logging_test.rego
+++ b/rego/tests/rules/tf/aws/s3/logging_test.rego
@@ -1,0 +1,25 @@
+# Copyright 2020 Fugue, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package rules.tf_aws_s3_bucket_access_logging
+
+import data.tests.rules.tf.aws.s3.inputs.bucket_logging_infra_json
+
+test_s3_logging {
+	pol = policy with input as bucket_logging_infra_json.mock_input
+	by_resource_id = {p.id: p.valid | pol[p]}
+	by_resource_id["aws_s3_bucket.allow_inline_logging"] == true
+	by_resource_id["aws_s3_bucket.deny_no_logging"] == false
+	by_resource_id["aws_s3_bucket.allow_attached_resource_logging"] == true
+}


### PR DESCRIPTION
Seeing if we can get https://github.com/fugue/regula/pull/421 merged in as well.

Fixes https://github.com/fugue/regula/issues/374

Sample from that pull request which also matches the code we have provided in tests:


Fixed behavior:

```
$ cat test.tf
resource "aws_s3_bucket" "bucket_new_syntax" {
  bucket = "bucket_new_syntax"
}

resource "aws_s3_bucket_logging" "bucket_new_syntax" {
  bucket = aws_s3_bucket.bucket_new_syntax.id

  target_bucket = aws_s3_bucket.logbucket.id
  target_prefix = "log/"
}

$ regula run --include $HOME/git/regula/rego/rules/tf/aws/s3/bucket_access_logging.rego --no-built-ins

No problems found. Good going.
```

Original behavior:

```
$ cat test.tf
resource "aws_s3_bucket" "bucket_new_syntax" {
  bucket = "bucket_new_syntax"
}

$ regula run --include $HOME/git/regula/rego/rules/tf/aws/s3/bucket_access_logging.rego --no-built-ins

FG_R00274: S3 bucket access logging should be enabled [Medium]
           https://docs.fugue.co/FG_R00274.html

  [1]: aws_s3_bucket.bucket_new_syntax
       in test.tf:1:1

Found one problem.
```